### PR TITLE
Ch-ch-ch-changes

### DIFF
--- a/prepimg.sh
+++ b/prepimg.sh
@@ -25,12 +25,13 @@ MAXWIDTH=598
 set -e
 
 create_dir() {
-    mkdir -p "${READY}" || true
+    mkdir -p "${SCREENSHOTS}" || true
 }
 
 process_img() {
     # verify that file is an image file, and then get dimensions
     if file "${SCREENSHOTS}"/"${1}" | grep -qE 'image|bitmap'; then
+	[[ $VERBOSE -gt 0 ]] && echo "${1} is an image"
 	W=$(identify -format %w "${SCREENSHOTS}"/"${1}")
     else
 	echo "File ${SCREENSHOTS}/${1} is not an image."
@@ -43,6 +44,11 @@ process_img() {
 	[[ $VERBOSE -gt 0 ]] && echo "${1} is ${W} - reducing"
 	convert -resize "${MAXWIDTH}" \
 		-bordercolor $BORDER \
+		-border 1 \
+		"${SCREENSHOTS}"/"${1}" \
+		"${READY}"/"${1}"
+    else
+	convert -bordercolor $BORDER \
 		-border 1 \
 		"${SCREENSHOTS}"/"${1}" \
 		"${READY}"/"${1}"
@@ -75,6 +81,14 @@ done
 
 # main
 create_dir
+
+if [ -z "$(ls -A ${SCREENSHOTS})" ]
+then
+    echo "No images found."
+    exit
+else
+    mkdir -p "${READY}" || true
+fi
 
 for i in "${SCREENSHOTS}"/*.???; do
     process_img "`basename "${i}"`"

--- a/prepimg.sh
+++ b/prepimg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## "prepimg.sh"
 ## written by Alan Formy-Duval
@@ -12,35 +12,70 @@
 ## Screenshots should be created using GNOME extension - Screenshot Tool
 ## Reference: https://extensions.gnome.org/extension/1112/screenshot-tool/
 ## configured to save screenshots to the directory shown below:
-SCREENSHOTS="/home/alan/Pictures/Screenshots"
+SCREENSHOTS=${SCREENSHOTS:-"$HOME/Pictures/Screenshots"}
+READY=${READY:-"$SCREENSHOTS/Ready"}
+BORDER=${BORDER:-black}
+VERBOSE=0
+
 ## opensource.com requires a maximum width of 600 for images
 ## minus 2 for adding a border
 MAXWIDTH=598
 
-cd "${SCREENSHOTS}"
-## Check that screenshots exist
-# [ ! -f "$SCREENSHOTS/Screenshot*" ] && echo "No screenshots found."; exit 0;
+## exit on most errors
+set -e
 
-## Reduce the image sizes as needed
+create_dir() {
+    mkdir -p "${READY}" || true
+}
 
-for i in Screenshot*
-do
-## get the image width
-W=$(identify -format %w ${i})
-    if [ "$W" -gt "$MAXWIDTH" ] 
-    then
-        # echo "${i} is ${W} - reducing"
-        convert -resize ${MAXWIDTH} "${i}" "${i}"
+process_img() {
+    # verify that file is an image file, and then get dimensions
+    if file "${SCREENSHOTS}"/"${1}" | grep -qE 'image|bitmap'; then
+	W=$(identify -format %w "${SCREENSHOTS}"/"${1}")
+    else
+	echo "File ${SCREENSHOTS}/${1} is not an image."
+	W=0
     fi
+
+    # resize and border
+    if [ "$W" -gt "$MAXWIDTH" ]
+    then
+	[[ $VERBOSE -gt 0 ]] && echo "${1} is ${W} - reducing"
+	convert -resize "${MAXWIDTH}" \
+		-bordercolor $BORDER \
+		-border 1 \
+		"${SCREENSHOTS}"/"${1}" \
+		"${READY}"/"${1}"
+    fi
+}
+
+## parse opts
+while [ True ]; do
+if [ "$1" = "--help" -o "$1" = "-h" ]; then
+    echo " "
+    echo "$0 [OPTIONS]"
+    echo "--verbose, -v     Be verbose"
+    echo "--directory, -d   Screenshot directory (default: $SCREENSHOTS)"
+    echo "--border, -b      Border color (default: black)"
+    echo " "
+    exit
+elif [ "$1" = "--verbose" -o "$1" = "-v" ]; then
+    VERBOSE=1
+    shift 1
+elif [ "$1" = "--directory" -o "$1" = "-d" ]; then
+    SCREENSHOTS="${2}"
+    shift 2
+elif [ "$1" = "--border" -o "$1" = "-b" ]; then
+    BORDER="${2}"
+    shift 2
+else
+    break
+fi
 done
 
-## Add a border to each image and rename to indicate it is ready
+# main
+create_dir
 
-for i in Screenshot*
-do
-convert -bordercolor black -border 1 "${i}" "Ready-${i}"
-## remove old file
-rm "${i}"
-## report size
-# echo "${i} is $(identify -format %w ${i})"
+for i in "${SCREENSHOTS}"/*.???; do
+    process_img "`basename "${i}"`"
 done


### PR DESCRIPTION
Made SCREENSHOTS variable generic with $HOME

Added options to allow for alternate Screenshot dir, because I write articles in their own directories, with screenshots being saved to those dirs rather than to ~/Pictures

Options are discoverable with `prepimg --help`

Added configurable border color, just in case.

Added a check to verify that a file is an image before converting to avoid surprises when there's an `.md` or `.odt` file in the directory.

Added separate destination directory for safety. Maybe in the future, we should add an option to confirm original image deletion, but I'm always nervous about removing data before confirming it's good.

Tried to make it parallel, but failed miserably